### PR TITLE
Smooth init with app config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui-cli"
-version = "0.1.6"
+version = "0.1.7-beta"
 edition = "2024"
 authors = ["Everlabs"]
 description = "A CLI to add components to your app."
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 colored = "2"
 indicatif = "0.17"
+toml = "0.8.22"
 
 
 
@@ -30,5 +31,3 @@ path = "src/main.rs"
 
 
 
-# ------- JUST FOR TESTING ---------
-tailwind-input-file = "style/tailwind.css"

--- a/src/command_add/components_toml.rs
+++ b/src/command_add/components_toml.rs
@@ -1,7 +1,6 @@
 use std::fs;
 
 use crate::constants::file_name::FILE_NAME;
-use colored::Colorize;
 
 pub struct ComponentsToml {}
 

--- a/src/command_init/_init.rs
+++ b/src/command_init/_init.rs
@@ -2,7 +2,8 @@ use clap::{Arg, Command};
 use indicatif::ProgressBar;
 use std::time::Duration;
 
-use super::{config::Config, install::Install, user_input::UserInput};
+use super::config::AppConfig;
+use super::{install::Install, user_input::UserInput};
 use crate::constants::commands::{COMMAND, INIT};
 use crate::constants::file_name::FILE_NAME;
 use crate::constants::template::TEMPLATE;
@@ -34,20 +35,16 @@ pub async fn init_project() {
 /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
 pub async fn process_init() {
-    let tailwind_input_file = Config::try_extract_tailwind_input_file_from_cargo_toml();
+    // Create app_config.toml file with default values in it
+    let app_config = AppConfig::default();
 
-    if tailwind_input_file.is_err() {
-        eprintln!("{}", tailwind_input_file.unwrap_err());
-        return; // Early return
-    }
-
+    INIT_TEMPLATE_FILE(FILE_NAME::APP_CONFIG_TOML, &toml::to_string_pretty(&app_config).unwrap()).await;
     INIT_TEMPLATE_FILE(FILE_NAME::PACKAGE_JSON, TEMPLATE::PACKAGE_JSON).await;
-    INIT_TEMPLATE_FILE(FILE_NAME::COMPONENTS_TOML, TEMPLATE::COMPONENTS_TOML).await;
-    INIT_TEMPLATE_FILE(&tailwind_input_file.unwrap(), TEMPLATE::STYLE_TAILWIND_CSS).await;
+    INIT_TEMPLATE_FILE(&app_config.tailwind_input_file, TEMPLATE::STYLE_TAILWIND_CSS).await;
     INIT_TEMPLATE_FILE(FILE_NAME::TAILWIND_CONFIG_JS, TEMPLATE::TAILWIND_CONFIG).await;
 
-    Config::handle_cargo_toml().await;
-    Config::handle_config_schema().await;
+    // Config::handle_cargo_toml().await;
+    // Config::handle_config_schema().await;
     UserInput::handle_index_styles().await;
 
     Install::tailwind_with_pnpm().await;

--- a/src/command_init/_init.rs
+++ b/src/command_init/_init.rs
@@ -2,7 +2,7 @@ use clap::{Arg, Command};
 use indicatif::ProgressBar;
 use std::time::Duration;
 
-use super::config::AppConfig;
+use super::config::{add_init_dependencies, AppConfig};
 use super::{install::Install, user_input::UserInput};
 use crate::constants::commands::{COMMAND, INIT};
 use crate::constants::file_name::FILE_NAME;
@@ -43,8 +43,8 @@ pub async fn process_init() {
     INIT_TEMPLATE_FILE(&app_config.tailwind_input_file, TEMPLATE::STYLE_TAILWIND_CSS).await;
     INIT_TEMPLATE_FILE(FILE_NAME::TAILWIND_CONFIG_JS, TEMPLATE::TAILWIND_CONFIG).await;
 
-    // Config::handle_cargo_toml().await;
-    // Config::handle_config_schema().await;
+    add_init_dependencies().await;
+
     UserInput::handle_index_styles().await;
 
     Install::tailwind_with_pnpm().await;

--- a/src/command_init/config.rs
+++ b/src/command_init/config.rs
@@ -1,48 +1,66 @@
 // use dotenv::dotenv;
 use indicatif::ProgressBar;
+// use serde::de::Error;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+// use std::fmt::Result;
 // use std::env;
 use std::fs;
 use std::process::Command;
 use std::time::Duration;
-
-use crate::command_init::fetch::Fetch;
-use crate::constants::dependencies::DEPENDENCIES;
 use crate::constants::others::{CARGO_TOML_FILE, SPINNER_UPDATE_DURATION};
-use crate::constants::url::URL;
 
-pub struct Config {}
 
-impl Config {
-    pub async fn handle_config_schema() {
-        // dotenv().ok();
+///
+/// AppConfig
+/// 
+/// 
+#[derive(Debug, Deserialize, Serialize, PartialEq, PartialOrd)]
+pub struct AppConfig {
+    pub tailwind_input_file: String,
+    pub base_path_components: String
+}
 
-        // let url_config_schema_json = env::var(ENV::URL_CONFIG_SCHEMA_JSON).unwrap_or_default();
+#[allow(dead_code)]
+impl AppConfig {
 
-        let url_config_schema_json = URL::URL_CONFIG_SCHEMA_JSON;
-
-        let _ = Fetch::from_url(&url_config_schema_json).await;
-    }
-
-    pub async fn handle_cargo_toml() {
-        ensure_leptos_dependencies_are_0_6_13();
-        // add_tailwind_fuse_and_leptos_use();
-        // handle_adding_leptos_use_to_ssr_features();
-        handle_tailwind_input_file();
-    }
-
-    pub fn try_extract_tailwind_input_file_from_cargo_toml() -> Result<String, String> {
-        let file_path = CARGO_TOML_FILE;
-        let contents = fs::read_to_string(file_path).unwrap();
-
-        // Find the line containing 'tailwind-input-file' and extract its value
-        if let Some(line) = contents.lines().find(|line| line.contains("tailwind-input-file =")) {
-            // Split the line and get the value after '='
-            let parts: Vec<&str> = line.split('=').collect();
-            if parts.len() > 1 {
-                return Ok(parts[1].trim().replace("\"", "")); // Remove quotes and trim whitespace
-            }
+    pub fn new(tailwind_input_file: &str, base_path_components: &str) -> Self {
+        AppConfig { 
+            tailwind_input_file: tailwind_input_file.to_string(), 
+            base_path_components: base_path_components.to_string() 
         }
-        Err("🔸 Error: 'tailwind-input-file' not found in Cargo.toml. Please add it to your Cargo.toml under [[workspace.metadata.leptos]].".to_string()) // Return an error if not found
+    }
+
+    pub fn try_reading_app_config(toml_path: &str) -> Result<AppConfig, Box<dyn Error>> {
+        let contents = fs::read_to_string(toml_path)?;
+        let app_config: AppConfig = toml::from_str(&contents)?;
+        Ok(app_config)
+    }
+
+}
+
+impl Default for AppConfig {
+    ///
+    /// Creates a default AppConfig
+    /// 
+    /// # Example
+    /// ```
+    /// let app_config = AppConfig::default();
+    /// 
+    /// assert_eq!(
+    ///     app_config, 
+    ///     AppConfig {
+    ///         tailwind_input_file: "style/tailwind.css".to_string(),
+    ///         base_path_components: "src/components".to_string()
+    ///     }
+    /// );
+    /// 
+    /// ```
+    fn default() -> Self {
+        AppConfig { 
+            tailwind_input_file: "style/tailwind.css".to_string(), 
+            base_path_components: "src/components".to_string()
+        }
     }
 }
 
@@ -50,35 +68,6 @@ impl Config {
 /*                     ✨ FUNCTIONS ✨                        */
 /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-fn ensure_leptos_dependencies_are_0_6_13() {
-    match fs::read_to_string(CARGO_TOML_FILE) {
-        Ok(mut contents) => {
-            let dependencies = DEPENDENCIES::LEPTOS;
-
-            for dep in dependencies.iter() {
-                let dep_pattern = format!("{} = {{ version = \"", dep);
-                if let Some(start_pos) = contents.find(&dep_pattern) {
-                    let version_start = start_pos + dep_pattern.len();
-                    if let Some(version_end) = contents[version_start..].find('"') {
-                        let current_version = &contents[version_start..version_start + version_end];
-                        if current_version != DEPENDENCIES::LEPTOS_0_6_13 {
-                            contents
-                                .replace_range(version_start..version_start + version_end, DEPENDENCIES::LEPTOS_0_6_13);
-                        }
-                    }
-                }
-            }
-
-            // Write the modified contents back to the file
-            if let Err(e) = fs::write(CARGO_TOML_FILE, &contents) {
-                eprintln!("🔸 Error writing to file: {}", e);
-            }
-        }
-        Err(e) => {
-            eprintln!("🔸 Error reading file: {}", e);
-        }
-    }
-}
 
 #[allow(unused)]
 fn add_tailwind_fuse_and_leptos_use() {
@@ -137,39 +126,6 @@ fn handle_adding_leptos_use_to_ssr_features() {
         }
         Err(e) => {
             eprintln!("Error reading file: {}", e);
-        }
-    }
-}
-
-fn handle_tailwind_input_file() {
-    match fs::read_to_string(CARGO_TOML_FILE) {
-        Ok(mut contents) => {
-            // Check if "style-file" exists
-            if let Some(start_pos) = contents.find("style-file") {
-                // Find the end of the line containing "style-file"
-                if let Some(end_pos) = contents[start_pos..].find('\n') {
-                    let end_of_line = start_pos + end_pos;
-                    // Replace the line with the new entry
-                    contents.replace_range(start_pos..end_of_line, "tailwind-input-file = \"style/tailwind.css\"");
-                }
-            } else if let Some(start_pos) = contents.find("tailwind-input-file") {
-                // Find the end of the line containing "tailwind-input-file"
-                if let Some(end_pos) = contents[start_pos..].find('\n') {
-                    let end_of_line = start_pos + end_pos;
-                    // Replace the line with the new entry
-                    contents.replace_range(start_pos..end_of_line, "tailwind-input-file = \"style/tailwind.css\"");
-                }
-            } else {
-                println!("🔸 Error. Neither 'style-file' nor 'tailwind-input-file' entry found.");
-            }
-
-            // Write the modified contents back to the file
-            if let Err(e) = fs::write(CARGO_TOML_FILE, &contents) {
-                eprintln!("🔸 Error writing to file: {}", e);
-            }
-        }
-        Err(e) => {
-            eprintln!("🔸 Error reading file: {}", e);
         }
     }
 }

--- a/src/command_init/config.rs
+++ b/src/command_init/config.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::process::Command;
 use std::time::Duration;
 use crate::constants::others::{CARGO_TOML_FILE, SPINNER_UPDATE_DURATION};
-
+use crate::constants::dependencies::INIT_DEPENDENCIES;
 
 ///
 /// AppConfig
@@ -67,6 +67,35 @@ impl Default for AppConfig {
 /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
 /*                     ✨ FUNCTIONS ✨                        */
 /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+#[allow(unused)]
+pub async fn add_init_dependencies() {
+    
+    for dep in INIT_DEPENDENCIES {
+        let spinner = ProgressBar::new_spinner();
+        spinner.set_message(format!("Adding and installing {} crate...", dep.name));
+        spinner.enable_steady_tick(Duration::from_millis(SPINNER_UPDATE_DURATION));
+        
+        let mut args = vec!["add".to_owned(), dep.name.to_owned()];
+        if !dep.features.is_empty() {
+            args.push("--features".to_owned());
+            args.push(dep.features.join(","));
+        }
+        let output = Command::new("cargo")
+            .args(args)
+            .output()
+            .expect("🔸 Failed to add crate!");
+
+        if output.status.success() {
+            spinner.finish_with_message("✔️ Crates added successfully.");
+        } else {
+            spinner.finish_with_message(format!(
+                "🔸 Error adding crates: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+    }
+
+}
 
 
 #[allow(unused)]

--- a/src/command_init/config.rs
+++ b/src/command_init/config.rs
@@ -1,7 +1,6 @@
 // use dotenv::dotenv;
 use indicatif::ProgressBar;
 // use std::env;
-use colored::Colorize;
 use std::fs;
 use std::process::Command;
 use std::time::Duration;
@@ -81,6 +80,7 @@ fn ensure_leptos_dependencies_are_0_6_13() {
     }
 }
 
+#[allow(unused)]
 fn add_tailwind_fuse_and_leptos_use() {
     let spinner = ProgressBar::new_spinner();
     spinner.set_message("Adding crates: rustui_merge and leptos-use");
@@ -109,6 +109,7 @@ fn add_tailwind_fuse_and_leptos_use() {
     }
 }
 
+#[allow(unused)]
 fn handle_adding_leptos_use_to_ssr_features() {
     match fs::read_to_string(CARGO_TOML_FILE) {
         Ok(mut contents) => {

--- a/src/command_init/user_input.rs
+++ b/src/command_init/user_input.rs
@@ -44,7 +44,7 @@ fn ask_user_choose_style(vec_styles: Vec<serde_json::Value>) {
     // Print available styles
     for (index, style) in vec_styles.iter().enumerate() {
         if let Some(label) = style.get(LABEL) {
-            println!("{}: {}", index + 1, label);
+            println!("\n{}: {}", index + 1, label);
         }
     }
 

--- a/src/constants/dependencies.rs
+++ b/src/constants/dependencies.rs
@@ -1,10 +1,37 @@
-pub struct DEPENDENCIES;
+#[allow(unused)]
+pub struct Dependency<'a> {
+    pub name: &'a str,
+    pub version: Option<&'a str>,
+    pub features: &'a [&'a str]
+}
+
+impl<'a> Dependency<'a> {
+    const fn new(
+        name: &'a str,
+        version: Option<&'a str>,
+        features: &'a [&'a str]
+    ) -> Self {
+        Dependency { name, version, features }
+    }
+}
+
+
+/// 
+/// Dependencies to initialize the ui lib
+/// 
+pub const INIT_DEPENDENCIES: [Dependency<'static>; 2] = [
+    Dependency::new(
+        "leptos", 
+        None, 
+        &["csr"]
+    ),
+    Dependency::new(
+        "tw_merge", 
+        None, 
+        &["variant"]
+    )
+]; 
 
 /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
 /*                     ✨ FUNCTIONS ✨                        */
 /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
-
-impl DEPENDENCIES {
-    pub const LEPTOS: [&str; 4] = ["leptos", "leptos_axum", "leptos_meta", "leptos_router"];
-    pub const LEPTOS_0_6_13: &str = "0.6.13";
-}

--- a/src/constants/file_name.rs
+++ b/src/constants/file_name.rs
@@ -4,6 +4,5 @@ pub struct FILE_NAME;
 impl FILE_NAME {
     pub const TAILWIND_CONFIG_JS: &str = "tailwind.config.js";
     pub const COMPONENTS_TOML: &str = "Components.toml";
-    pub const STYLE_SLASH_TAILWIND_CSS: &str = "style/tailwind.css";
     pub const PACKAGE_JSON: &str = "package.json";
 }

--- a/src/constants/file_name.rs
+++ b/src/constants/file_name.rs
@@ -2,6 +2,7 @@
 pub struct FILE_NAME;
 
 impl FILE_NAME {
+    pub const APP_CONFIG_TOML: &str = "app_config.toml";
     pub const TAILWIND_CONFIG_JS: &str = "tailwind.config.js";
     pub const COMPONENTS_TOML: &str = "Components.toml";
     pub const PACKAGE_JSON: &str = "package.json";

--- a/src/constants/template.rs
+++ b/src/constants/template.rs
@@ -1,8 +1,6 @@
 pub struct TEMPLATE;
 
 impl TEMPLATE {
-    pub const COMPONENTS_TOML: &str = r#"base_path = "src/components"
-"#;
 
     pub const STYLE_TAILWIND_CSS: &str = r#"@import "tailwindcss";
 @import "tw-animate-css";

--- a/src/constants/url.rs
+++ b/src/constants/url.rs
@@ -1,5 +1,6 @@
 pub struct URL;
 
+#[allow(unused)]
 impl URL {
     pub const URL_REGISTRY_INDEX_JSON: &str = "https://www.rust-ui.com/registry/index.json";
     pub const URL_CONFIG_SCHEMA_JSON: &str = "https://www.rust-ui.com/schema.json";


### PR DESCRIPTION
# Smooth Initialization Of UI-CLI with app_config.toml

### Problem
So previously initialization process had following problems

1. Breaking of init process due to lack of `tailwind-input-file` property in `Cargo.toml`, but thing is we can not expect a new user to set it up before hand.
2. Lack of proper dependency in application. Previously init process was forcing to install `leptos@0.6.13` but new components are not compatible with `leptos@06.13`. Also new components have a dependency on `tw_merge` lib which was not being installed.
3. Lastly, application configurations were dispersed in two files, i.e., `Cargo.toml` and `Components.toml`.

### Solution
So while `Cargo.toml` is great place for everything Rust specific, our application should have it's own configuration file which will serve as a single source of truth through out the application. We have it as `app_config.toml`, which initially holds two important values `tailwind-input-file` and `base-path-component`. 

We also have automated installation of `leptos@latest` with `--features csr` and `tw_merge` with `--features variant`. Note that we have not made our initial dependencies to have any version specific now. But since we my want to support **Yew** and **Dioxus** in future we will be specific about versions, their peer dependencies and also their boilerplate code.

**_Note: Branch has multiple commits with message explaining changes in each commit._**