### PR TITLE
registration of components module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ end2end/playwright-report/
 playwright/.cache/
 
 **/target/
+
+.DS_Store

--- a/src/command_add/_add.rs
+++ b/src/command_add/_add.rs
@@ -1,4 +1,5 @@
 use clap::{Arg, ArgMatches, Command};
+use std::path::Path;
 // use dotenv::dotenv;
 // use std::env;
 use std::vec::Vec;
@@ -57,6 +58,22 @@ pub async fn process_add(matches: &ArgMatches) -> Result<(), Box<dyn std::error:
         components_base_path.clone(),
         all_resolved_parent_dirs.clone(),
     );
+
+    // TODO: Register `components` module
+    let mut file_path = components_base_path.split("/").collect::<Vec<&str>>();
+    assert_eq!(file_path.pop().unwrap(), "components");
+
+    let file_path = file_path.join("/");
+    let entry_file_path: String;
+
+    if Path::new(&format!("{file_path}/lib.rs")).exists() {
+        entry_file_path = format!("{file_path}/lib.rs");
+    } else {
+        entry_file_path = format!("{file_path}/main.rs");
+    }
+
+    Components::register_components_in_application_entry(entry_file_path.as_str())?;
+
 
     // Components to add
     for component_name_json in all_resolved_components {

--- a/src/command_add/_add.rs
+++ b/src/command_add/_add.rs
@@ -59,7 +59,7 @@ pub async fn process_add(matches: &ArgMatches) -> Result<(), Box<dyn std::error:
         all_resolved_parent_dirs.clone(),
     );
 
-    // TODO: Register `components` module
+    //  Register `components` module
     let mut file_path = components_base_path.split("/").collect::<Vec<&str>>();
     assert_eq!(file_path.pop().unwrap(), "components");
 
@@ -73,7 +73,6 @@ pub async fn process_add(matches: &ArgMatches) -> Result<(), Box<dyn std::error:
     }
 
     Components::register_components_in_application_entry(entry_file_path.as_str())?;
-
 
     // Components to add
     for component_name_json in all_resolved_components {

--- a/src/command_add/components.rs
+++ b/src/command_add/components.rs
@@ -68,11 +68,13 @@ impl Components {
     pub fn register_components_in_application_entry(entry_file_path: &str) -> Result<(), Box<dyn std::error::Error>> {
         let file_content = std::fs::read_to_string(entry_file_path)?;
 
-        if file_content.contains("mod components;") {
+        const MOD_COMPONENTS: &str = "mod components;";
+
+        if file_content.contains(MOD_COMPONENTS) {
             return Ok(());
         }
-        let new_contents = format!("{}\n{}", "mod components;", file_content);
-        std::fs::write(entry_file_path, new_contents.as_bytes())?;
+        let mod_components_import = format!("{}\n{}", MOD_COMPONENTS, file_content);
+        std::fs::write(entry_file_path, mod_components_import.as_bytes())?;
         Ok(())
     }
 }

--- a/src/command_add/components.rs
+++ b/src/command_add/components.rs
@@ -64,4 +64,21 @@ impl Components {
             }
         }
     }
+
+        // TODO: Register components module in application entry point file
+    pub fn register_components_in_application_entry(
+        entry_file_path: &str
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // TODO: read contents of file
+        let file_content = std::fs::read_to_string(entry_file_path)?;
+
+        // TODO: see if `mod components;` already exists
+        if file_content.contains("mod components;") {
+            return Ok(());
+        }
+        // TODO: if it's not, add it
+        let new_contents = format!("{}\n{}", "mod components;", file_content);
+        std::fs::write(entry_file_path, new_contents.as_bytes())?;
+        Ok(())
+    }
 }

--- a/src/command_add/components.rs
+++ b/src/command_add/components.rs
@@ -65,18 +65,12 @@ impl Components {
         }
     }
 
-        // TODO: Register components module in application entry point file
-    pub fn register_components_in_application_entry(
-        entry_file_path: &str
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        // TODO: read contents of file
+    pub fn register_components_in_application_entry(entry_file_path: &str) -> Result<(), Box<dyn std::error::Error>> {
         let file_content = std::fs::read_to_string(entry_file_path)?;
 
-        // TODO: see if `mod components;` already exists
         if file_content.contains("mod components;") {
             return Ok(());
         }
-        // TODO: if it's not, add it
         let new_contents = format!("{}\n{}", "mod components;", file_content);
         std::fs::write(entry_file_path, new_contents.as_bytes())?;
         Ok(())


### PR DESCRIPTION
# Automatic registration of `components` module

### Problem
Issue : #4 

### Solution
It first takes the value of `base_path_component` in *UIConfig*, let's say _src/components_ then it seeks for either _src/lib.rs_ or _src/main.rs_ and once if either of those exists, line `mod components;`  is added to it